### PR TITLE
Recursively search yaml files with themes

### DIFF
--- a/alacritty_colorscheme/cli.py
+++ b/alacritty_colorscheme/cli.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
+import os
+
 from tap import Tap
-from os import listdir
 from os.path import expanduser, isfile, join
 from typing import List, Optional, cast
 try:
@@ -89,13 +90,17 @@ def create_parser() -> TypedArgumentParser:
     return cast(TypedArgumentParser, parser)
 
 
-# TODO: show only yml files
 def get_files_in_directory(path: str) -> Optional[List[str]]:
     expanded_path = expanduser(path)
     try:
-        onlyfiles = [f for f in listdir(expanded_path)
-                     if isfile(join(expanded_path, f))]
-        return sorted(onlyfiles)
+        onlyfiles = []
+        for root, _dirs, files in os.walk(expanded_path, followlinks=True):
+            for file in files:
+                full_path = join(root, file)
+                if file.endswith(('.yml', '.yaml')) and isfile(full_path):
+                    onlyfiles.append(full_path.removeprefix(expanded_path))
+        onlyfiles.sort()
+        return onlyfiles
     except OSError:
         return None
 


### PR DESCRIPTION
Currently, alacritty-colorscheme looks for theme files only in a single directory.  
This PR makes it recursively search files with `yaml` or `yml` extensions only.

This allows using several sources for theme files. For example, both repositories from the readme can be used:

```shell
REPO="https://github.com/aaron-williamson/base16-alacritty.git"
DEST="$HOME/.aarors-williamson-colorschemes"

# Get colorschemes 
git clone $REPO $DEST
# Create symlink at default colors location (optional)
ln -s "$DEST/colors" "$HOME/.config/alacritty/colors/base16"
```

```shell
REPO=https://github.com/eendroroy/alacritty-theme.git
DEST="$HOME/.eendroroy-colorschemes"
# Get colorschemes
git clone $REPO $DEST
# Create symlink at default colors location (optional)
ln -s "$DEST/themes" "$HOME/.config/alacritty/colors/misc"
```

Notice that the link names are changed from `.../colors` to `.../colors/base16` and `.../colors/misc` for different theme sources.

Also notice that theme names are now prefixed with the corresponding subdirectory. For instance, `alacritty-colorscheme list` shows something like this:

```
...
base16/base16-xcode-dusk.yml
base16/base16-zenburn-256.yml
base16/base16-zenburn.yml
misc/Cobalt2.yaml
misc/afterglow.yaml
misc/argonaut.yaml
...
```

Other than that, no side effects were observed.  
This is not a breaking change, everything should work the same after an update.