### PR TITLE
Replace backward-incompatible method

### DIFF
--- a/alacritty_colorscheme/cli.py
+++ b/alacritty_colorscheme/cli.py
@@ -98,7 +98,9 @@ def get_files_in_directory(path: str) -> Optional[List[str]]:
             for file in files:
                 full_path = join(root, file)
                 if file.endswith(('.yml', '.yaml')) and isfile(full_path):
-                    onlyfiles.append(full_path.removeprefix(expanded_path))
+                    # NOTE: use str.removeprefix in Python >= 3.9
+                    filename = full_path[len(expanded_path):]
+                    onlyfiles.append(filename)
         onlyfiles.sort()
         return onlyfiles
     except OSError:


### PR DESCRIPTION
In #33 I added a method, which appeared in Python 3.9 and is not compatible with older versions. This is one of the reasons why [CI failed](https://github.com/toggle-corp/alacritty-colorscheme/runs/7307084226?check_suite_focus=true).