### PR TITLE
Fix runtime errors when toggle vim colorscheme

### DIFF
--- a/alacritty_colorscheme/cli.py
+++ b/alacritty_colorscheme/cli.py
@@ -98,7 +98,11 @@ def get_files_in_directory(path: str) -> Optional[List[str]]:
             for file in files:
                 full_path = join(root, file)
                 if file.endswith(('.yml', '.yaml')) and isfile(full_path):
-                    onlyfiles.append(full_path.removeprefix(expanded_path))
+                    # remove prefix
+                    if full_path.startswith(expanded_path):
+                        full_path = full_path[len(expanded_path):]
+
+                    onlyfiles.append(full_path)
         onlyfiles.sort()
         return onlyfiles
     except OSError:

--- a/alacritty_colorscheme/vim.py
+++ b/alacritty_colorscheme/vim.py
@@ -1,5 +1,5 @@
 from os import listdir, environ
-from os.path import join
+from os.path import join, isdir
 from pynvim import attach
 
 
@@ -16,11 +16,15 @@ def _get_all_instances():
 
     tmpdir = environ.get('TMPDIR', '/tmp')
 
-    folders = [f for f in listdir(tmpdir) if f.startswith('nvim')]
+    folders = [f for f in listdir(tmpdir) if f.startswith('nvim') and isdir(f)]
     for folder in folders:
-        dc = listdir(join(tmpdir, folder))
-        if '0' in dc:
-            instances.append(join(tmpdir, folder, '0'))
+        try:
+            dc = listdir(join(tmpdir, folder))
+            if '0' in dc:
+                instances.append(join(tmpdir, folder, '0'))
+        except PermissionError:
+            # cannot open directories owned by other users e.g., /tmp/nvim.root
+            continue
 
     return instances
 


### PR DESCRIPTION
Thanks for this great tool!

The goal of this PR is to fix two issues when setting the neovim colorscheme

* Try getting the contents of directories only
* Skip directories of other users for whom we don't have permissions