### PR TITLE
Use poetry-core as the builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,5 @@ flake8 = "^3.9.2"
 alacritty-colorscheme = 'alacritty_colorscheme.cli:main'
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This is now the recommended way of specifying poetry as a builder for
the package. It also allows / fixes installing the current package in
development/editable mode - `-e`
